### PR TITLE
Adds KKBOX's bundle ID, a popular music streaming service in Asia.

### DIFF
--- a/MagicKeys-Agent/SPMediaKeyTap.m
+++ b/MagicKeys-Agent/SPMediaKeyTap.m
@@ -187,6 +187,7 @@ static NSString *kKeyProcessSpecificRunloopSource = @"ProcessSource";
         @"com.treasurebox.gear",
         @"de.call-a-nerd.StreamCloud", //Added StreamCloud
         @"net.relisten.osx.Relisten", // Added Relisten
+		@"com.kkbox.KKBOXForMac",
 		nil
 	];
 }


### PR DESCRIPTION
KKBOX is a Taiwan based music streaming service and it is available in Japan, Hong Kong, Singapore, Malaysia and Thailand as well. For further information, please visit https://www.kkbox.com.